### PR TITLE
학교이메일 아이디가 학번이 아닌 유저 회원가입 가능하게 함 - fix #46

### DIFF
--- a/photos/urls.py
+++ b/photos/urls.py
@@ -16,4 +16,5 @@ urlpatterns = [
     path('img_download/<int:pk>/', views.img_download, name='img_download'),
     path('img_download_page/', views.img_download_page, name='img_download_page'),
     path('user_check/', views.user_check, name='user_check'),
+    path('no_student_id/<int:pk>/', views.no_student_id, name='no_student_id'),
 ]

--- a/templates/registration/no_student_id.html
+++ b/templates/registration/no_student_id.html
@@ -1,0 +1,26 @@
+{% extends "base_template.html" %}
+
+{% block content %}
+<form method="POST" class="form-style-7">
+    {% csrf_token %}
+    <ul>
+        <h1>Sign Up</h1>
+    <li>
+        <label for="email">학번</label>
+        &nbsp&nbsp&nbsp&nbsp<input type="text" name="student_id" pattern="[0-9]{8}" maxlength="8" style="width:200px; margin-left:5%;" required>
+    </li>
+    <li>
+        <label for="email">연락받을 이메일</label>
+        &nbsp&nbsp&nbsp&nbsp<input type="email" name="email" maxlength="50" style="width:200px; margin-right:5%;" required>
+    </li>
+    <li>
+        <label for="email">Phone</label>
+        010&nbsp&nbsp-&nbsp&nbsp<input type="text" name="phone1" pattern="[0-9]{4}" maxlength="4" style="width:80px;" required>&nbsp&nbsp-&nbsp&nbsp<input type="text" name="phone2" maxlength="4" style="width:80px;" pattern="[0-9]{4}" required>
+    </li>
+    <li>
+        <input type="submit" value="제출" style="margin-left:40%;">
+    </li>
+    </ul>
+</form>
+
+{% endblock %}


### PR DESCRIPTION
학교이메일의 아이디가 학번이 아닌 유저들은 학번과 필요한 정보를 입력하는
페이지로 redirect되고, 입력하지 않으면 계속 입력페이지로 redirect되게
만들었습니다.