### PR TITLE
Rank페이지와 관리자 userlist 보는 페이지의 Order변경 - resolve #49

### DIFF
--- a/photos/templates/rank.html
+++ b/photos/templates/rank.html
@@ -30,8 +30,18 @@
             {% endif %}
         </td>
         <td>{{ group.num_posts }}</td>
+        
+        {% if group.recent is None %}
+        <td>-</td>
+        {% else %}
         <td>{{ group.recent }}</td>
+        {% endif %}
+
+        {% if group.total_dur is None %}
+        <td>0</td>
+        {% else %}
         <td>{{ group.total_dur }}</td>
+        {% endif %}
 {% endfor %}
 </table>
 </div>

--- a/photos/templates/userlist.html
+++ b/photos/templates/userlist.html
@@ -106,8 +106,18 @@
                 </a>
             </td>
             <td>{{ group.num_posts }}</td>
+
+            {% if group.recent is None %}
+            <td>-</td>
+            {% else %}
             <td>{{ group.recent }}</td>
+            {% endif %}
+
+            {% if group.total_dur is None %}
+            <td>0</td>
+            {% else %}
             <td>{{ group.total_dur }}</td>
+            {% endif %}
     {% endfor %}
     </table>
 </div>

--- a/photos/views.py
+++ b/photos/views.py
@@ -635,7 +635,7 @@ def userList(request):
         recent = Max('group__data__date', filter=Q(group__data__year=yearobj)&Q(group__data__sem=sem)), # 해당 학기로 바꿔야함 to fix
         total_dur = Sum('group__data__study_total_duration', distinct=True, filter=Q(group__data__year=yearobj)&Q(group__data__sem=sem)),
         no = F('group__no'),
-    ).order_by('-num_posts')
+    ).order_by('-num_posts', 'recent', 'no')
 
 
     ctx['grouplist'] = grouplist
@@ -681,7 +681,7 @@ def rank(request):
         recent = Max('group__data__date', filter=Q(group__data__year=yearobj)&Q(group__data__sem=sem)), # 해당 학기로 바꿔야함 to fix
         total_dur = Sum('group__data__study_total_duration', distinct=True, filter=Q(group__data__year=yearobj)&Q(group__data__sem=sem)),
         no = F('group__no'),
-    ).order_by('-num_posts', 'recent')
+    ).order_by('-num_posts', 'recent', 'no')
 
     # userlist = User.objects.filter(Q(is_staff=False) & Q(userinfo__year__year=year) & Q(userinfo__sem=sem)).annotate(
     #     num_posts = Count('data'),


### PR DESCRIPTION
보고서의 개수와 제일 최근에 올린 시간 순으로만 Sorting을 했었는데,
보고서의 개수가 하나도 없을 때는 Group 번호로 Sorting을 하도록
변경하였습니다.