### PR TITLE
UserInfo 추가하는 기능 Bug Fix - fix #67

### DIFF
--- a/photos/views.py
+++ b/photos/views.py
@@ -438,11 +438,19 @@ def new_userinfo(request):
         except:
             student_info_obj = StudentInfo.objects.create(student_id=student_id, name=name)
 
-        checklist = UserInfo.objects.filter(year=yearobj, sem=sem, student_info=student_info_obj)
-        if checklist.exists():
-            group = checklist[0].group.no
-            msg = '이번 학기 해당 학생의 조가 존재합니다: Group ' + str(group)
-            messages.info(request, msg)
+        try:
+            user_info = UserInfo.objects.get(year=yearobj, sem=sem, student_info=student_info_obj)
+        except:
+            user_info = None
+
+        if user_info:
+            prev_group = user_info.group.no
+            if prev_group != groupno:
+                user_info.group.no = groupno
+                user_info.save()
+                msg = str(year) + '년 ' + str(sem) + '학기 해당 학생의 그룹 정보가 변경되었습니다: Group ' + str(prev_group) + ' --> Group ' + str(user_info.group.no)
+                messages.success(request, msg)
+
         else:
             try:
                 groupobj = Group.objects.get(no=groupno)


### PR DESCRIPTION
새롭게 추가하려는 학생의 정보가 이미 존재하고, 변경하고자 하는 그룹
번호와 현재 속해있는 그룹정보가 다를 때, 기존 학생정보를 수정하게
하였습니다.